### PR TITLE
IH-24 Implement NICE Payment cancel payment API client

### DIFF
--- a/src/main/java/art/heredium/payment/nicepayments/dto/request/NicePaymentsRefundRequest.java
+++ b/src/main/java/art/heredium/payment/nicepayments/dto/request/NicePaymentsRefundRequest.java
@@ -1,0 +1,13 @@
+package art.heredium.payment.nicepayments.dto.request;
+
+import javax.validation.constraints.NotBlank;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class NicePaymentsRefundRequest {
+  @NotBlank private String reason;
+  @NotBlank private String orderId;
+}

--- a/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsBaseResponse.java
+++ b/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsBaseResponse.java
@@ -1,0 +1,93 @@
+package art.heredium.payment.nicepayments.dto.response;
+
+import java.util.List;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public abstract class NicePaymentsBaseResponse {
+  private String resultCode;
+  private String resultMsg;
+  private String tid;
+  private String cancelledTid;
+  private String orderId;
+  private String ediDate;
+  private String signature;
+  private String status;
+  private String paidAt;
+  private String failedAt;
+  private String cancelledAt;
+  private String payMethod;
+  private Integer amount;
+  private Integer balanceAmt;
+  private String goodsName;
+  private String mallReserved;
+  private Boolean useEscrow;
+  private String currency;
+  private String channel;
+  private String approveNo;
+  private String buyerName;
+  private String buyerTel;
+  private String buyerEmail;
+  private String receiptUrl;
+  private String mallUserId;
+  private Boolean issuedCashReceipt;
+  private Coupon coupon;
+  private Card card;
+  private VBank vbank;
+  private Bank bank;
+  private String cellphone;
+  private List<Cancel> cancels;
+  private String cashReceipts;
+  private String messageSource;
+
+  @Getter
+  @Setter
+  private static class Card {
+    private String cardCode;
+    private String cardName;
+    private String cardNum;
+    private Integer cardQuota;
+    private Boolean isInterestFree;
+    private String cardType;
+    private Boolean canPartCancel;
+    private String acquCardCode;
+    private String acquCardName;
+  }
+
+  @Getter
+  @Setter
+  private static class Coupon {
+    private Integer couponAmt;
+  }
+
+  @Getter
+  @Setter
+  private static class VBank {
+    private String vbankCode;
+    private String vbankName;
+    private String vbankNumber;
+    private String vbankExpDate;
+    private String vbankHolder;
+  }
+
+  @Getter
+  @Setter
+  private static class Bank {
+    private String bankCode;
+    private String bankName;
+  }
+
+  @Getter
+  @Setter
+  private static class Cancel {
+    private String tid;
+    private Integer amount;
+    private String cancelledAt;
+    private String reason;
+    private String receiptUrl;
+    private Integer couponAmt;
+  }
+}

--- a/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsBaseResponse.java
+++ b/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsBaseResponse.java
@@ -7,7 +7,7 @@ import lombok.Setter;
 
 @Getter
 @Setter
-public abstract class NicePaymentsBaseResponse {
+public class NicePaymentsBaseResponse {
   private String resultCode;
   private String resultMsg;
   private String tid;

--- a/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsRefundResponse.java
+++ b/src/main/java/art/heredium/payment/nicepayments/dto/response/NicePaymentsRefundResponse.java
@@ -1,23 +1,23 @@
 package art.heredium.payment.nicepayments.dto.response;
 
-public class NicePaymentsPayResponse extends NicePaymentsBaseResponse {}
+public class NicePaymentsRefundResponse extends NicePaymentsBaseResponse {}
 
 /*
 {
     "resultCode": "0000",
     "resultMsg": "정상 처리되었습니다.",
     "tid": "UT0000113m01012111051714341073",
-    "cancelledTid": null,
+    "cancelledTid": "UT0000113m01012111051714341073",
     "orderId": "c74a5960-830b-4cd8-82a9-fa1ce739a18f",
-    "ediDate": "2024-10-02T17:47:00.554+0900",
-    "signature": "b67d4fa22292329043c1d428d49d022907cb6b2c86cb757007e199837fef2e34",
-    "status": "paid",
+    "ediDate": "2024-10-03T19:06:12.040+0900",
+    "signature": "bee79ef6ab938c0e4683f3cf15e0fc100494d1668523729925f2cf790dd693ab",
+    "status": "cancelled",
     "paidAt": "2021-11-05T17:14:35.000+0900",
     "failedAt": "0",
-    "cancelledAt": "0",
+    "cancelledAt": "2024-10-03T19:06:11.000+0900",
     "payMethod": "card",
     "amount": 1004,
-    "balanceAmt": 1004,
+    "balanceAmt": 0,
     "goodsName": "나이스페이-상품",
     "mallReserved": null,
     "useEscrow": false,
@@ -47,8 +47,17 @@ public class NicePaymentsPayResponse extends NicePaymentsBaseResponse {}
     "vbank": null,
     "bank": null,
     "cellphone": null,
-    "cancels": null,
+    "cancels": [
+        {
+            "tid": "UT0000113m01012111051714341073",
+            "amount": 1004,
+            "cancelledAt": "2024-10-03T19:06:11.000+0900",
+            "reason": "고객요청",
+            "receiptUrl": "https://npg.nicepay.co.kr/issue/IssueLoader.do?type=0&innerWin=Y&TID=UT0000113m01012111051714341073",
+            "couponAmt": 0
+        }
+    ],
     "cashReceipts": null,
     "messageSource": "nicepay"
 }
-*/
+ */

--- a/src/main/java/art/heredium/payment/nicepayments/feign/client/NicePaymentsClient.java
+++ b/src/main/java/art/heredium/payment/nicepayments/feign/client/NicePaymentsClient.java
@@ -7,7 +7,9 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 
 import art.heredium.payment.nicepayments.dto.request.NicePaymentsPayRequest;
+import art.heredium.payment.nicepayments.dto.request.NicePaymentsRefundRequest;
 import art.heredium.payment.nicepayments.dto.response.NicePaymentsPayResponse;
+import art.heredium.payment.nicepayments.dto.response.NicePaymentsRefundResponse;
 import art.heredium.payment.nicepayments.feign.config.NicePaymentsFeignConfig;
 
 @FeignClient(
@@ -21,4 +23,10 @@ public interface NicePaymentsClient {
       @RequestHeader("Authorization") String authorization,
       @PathVariable("tid") String tid,
       @RequestBody NicePaymentsPayRequest request);
+
+  @PostMapping("/v1/payments/{tid}/cancel")
+  NicePaymentsRefundResponse refund(
+      @RequestHeader("Authorization") String authorization,
+      @PathVariable("tid") String tid,
+      @RequestBody NicePaymentsRefundRequest request);
 }


### PR DESCRIPTION
- Implement NICE Payment cancel payment API client
- Refactor `NicePaymentsPayResponse`: NICE returns the same response for most of their APIs.
- Example between `Pay Response` and `Cancel Response`:

Pay Response:
```json
. . .
"cancel": null
. . .
```

Refund Response:
```json
. . .
"cancels": [
        {
            "tid": "UT0000113m01012111051714341073",
            "amount": 1004,
            "cancelledAt": "2024-10-03T19:06:11.000+0900",
            "reason": "고객요청",
            "receiptUrl": "https://npg.nicepay.co.kr/issue/IssueLoader.do?type=0&innerWin=Y&TID=UT0000113m01012111051714341073",
            "couponAmt": 0
        }
]
. . .
```
