### PR TITLE
IH-27 Add coupon count by type for not have coupons

### DIFF
--- a/src/main/java/art/heredium/domain/membership/model/dto/response/MembershipRegistrationResponse.java
+++ b/src/main/java/art/heredium/domain/membership/model/dto/response/MembershipRegistrationResponse.java
@@ -3,8 +3,6 @@ package art.heredium.domain.membership.model.dto.response;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.stream.Collectors;
 
 import lombok.Getter;
 import lombok.NonNull;
@@ -46,11 +44,13 @@ public class MembershipRegistrationResponse {
     this.expirationDate = membershipRegistration.getExpirationDate();
     this.membershipRegistrationId = membershipRegistration.getId();
     this.uuid = membershipRegistration.getUuid();
-    Map<CouponType, List<CouponUsage>> couponListByType =
-        couponUsages.stream()
-            .collect(Collectors.groupingBy(couponUsage -> couponUsage.getCoupon().getCouponType()));
-    couponListByType.forEach(
-        (couponType, couponUsageList) ->
-            this.coupons.add(new CouponCountByTypeResponse(couponType, couponUsageList.size())));
+    for (CouponType couponType : CouponType.values()) {
+      this.coupons.add(
+          new CouponCountByTypeResponse(
+              couponType,
+              couponUsages.stream()
+                  .filter(couponUsage -> couponUsage.getCoupon().getCouponType() == couponType)
+                  .count()));
+    }
   }
 }


### PR DESCRIPTION
Example:

```{
  "id": 3,
  "uuid": "31d61813-a059-468c-a12a-905d84074347",
  "membership_name": "Gold Membership",
  "registration_date": "2024-10-14",
  "expiration_date": "2025-10-14",
  "coupons": [
    {
      "type": "커피",
      "quantity": 2
    },
    {
      "type": "아트숍",
      "quantity": 0
    },
    {
      "type": "프로그램",
      "quantity": 0
    },
    {
      "type": "전시",
      "quantity": 1
    }
  ]
}